### PR TITLE
Fixed small conversion to local units error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog references the relevant changes (bug and security fixes) done
 in 1.x and 0.x versions.
 
 * 1.5.0 (DEV)
+  * Fixed conversion to local units
   * Added button for bin packing in groups of type dimensional and sheet good
   * Added 1D and 2D bin packing libraries
 

--- a/src/ladb_opencutlist/ruby/library/bin_packing_1d/packing1d.rb
+++ b/src/ladb_opencutlist/ruby/library/bin_packing_1d/packing1d.rb
@@ -15,7 +15,7 @@
     
     # convert to model units
     def cu(l)
-      return "#{l}\"".to_l.to_s
+      return l.to_l.to_s
     end
   end
 end

--- a/src/ladb_opencutlist/ruby/library/bin_packing_2d/packing2d.rb
+++ b/src/ladb_opencutlist/ruby/library/bin_packing_2d/packing2d.rb
@@ -47,12 +47,12 @@
     
     # convert to model units
     def cu(l)
-      return "#{l}\"".to_l.to_s
+      return l.to_l.to_s
     end
     
     # convert to mm for html export
     def cmm(l)
-      return "#{l}\"".to_l.to_mm
+      return l.to_l.to_mm
     end
   end
 end


### PR DESCRIPTION
I made a mistake when converting Floats back to Length/String. Ruby prints floats with a ".", but Sketchup expects the number in local format, when it is a string. Now we directly convert from float to Length avoiding hopefully the problem.