### PR TITLE
Proposal for Changing Display of ft³ and ft²

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ in 1.x and 0.x versions.
 
   * Added "News" tab
   * Improved thickness and section precision display
+  * Improved readability of square feet hide_raw_dimensions
+  * Changed ft³ to FBM (foot, board measure) for Material Solid Wood
 
 * 1.9.8 (2020-10-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ in 1.x and 0.x versions.
 
   * Added "News" tab
   * Improved thickness and section precision display
-  * Improved readability of square feet hide_raw_dimensions
+  * Improved readability of square feet area dimensions
   * Changed ft³ to FBM (foot, board measure) for Material Solid Wood
 
 * 1.9.8 (2020-10-28)

--- a/src/ladb_opencutlist/js/plugins/jquery.ladb.tab-materials.js
+++ b/src/ladb_opencutlist/js/plugins/jquery.ladb.tab-materials.js
@@ -759,7 +759,7 @@
         // Define usefull functions
         var fnComputeFieldsVisibility = function (type) {
             switch (type) {
-                case 0:   // TYPE_UNKNOW
+                case 0:   // TYPE_UNKNOWN
                     $inputLengthIncrease.closest('section').hide();
                     break;
                 case 1:   // TYPE_SOLID_WOOD

--- a/src/ladb_opencutlist/ruby/model/attributes/material_attributes.rb
+++ b/src/ladb_opencutlist/ruby/model/attributes/material_attributes.rb
@@ -7,14 +7,14 @@
 
   class MaterialAttributes
 
-    TYPE_UNKNOW = 0
+    TYPE_UNKNOWN = 0
     TYPE_SOLID_WOOD = 1
     TYPE_SHEET_GOOD = 2
     TYPE_DIMENSIONAL = 3
     TYPE_EDGE = 4
 
     DEFAULTS = {
-        TYPE_UNKNOW => {
+        TYPE_UNKNOWN => {
             :thickness => '0',
             :length_increase => '0',
             :width_increase => '0',
@@ -121,12 +121,12 @@
     def self.valid_type(type)
       if type
         i_type = type.to_i
-        if i_type < TYPE_UNKNOW or i_type > TYPE_EDGE
-          return TYPE_UNKNOW
+        if i_type < TYPE_UNKNOWN or i_type > TYPE_EDGE
+          return TYPE_UNKNOWN
         end
         i_type
       else
-        TYPE_UNKNOW
+        TYPE_UNKNOWN
       end
     end
 
@@ -373,7 +373,7 @@
           end
         end
 
-        @type = MaterialAttributes.valid_type(Plugin.instance.get_attribute(@material, 'type', TYPE_UNKNOW))
+        @type = MaterialAttributes.valid_type(Plugin.instance.get_attribute(@material, 'type', TYPE_UNKNOWN))
         @thickness = Plugin.instance.get_attribute(@material, 'thickness', get_default(:thickness))
         @length_increase = Plugin.instance.get_attribute(@material, 'length_increase', get_default(:length_increase))
         @width_increase = Plugin.instance.get_attribute(@material, 'width_increase', get_default(:width_increase))
@@ -386,7 +386,7 @@
         @grained = Plugin.instance.get_attribute(@material, 'grained', get_default(:grained))
         @edge_decremented = Plugin.instance.get_attribute(@material, 'edge_decremented', get_default(:edge_decremented))
       else
-        @type = TYPE_UNKNOW
+        @type = TYPE_UNKNOWN
       end
     end
 

--- a/src/ladb_opencutlist/ruby/model/cutlist/group.rb
+++ b/src/ladb_opencutlist/ruby/model/cutlist/group.rb
@@ -29,7 +29,7 @@ module Ladb::OpenCutList
       @std_thickness = group_def.std_thickness.to_s.gsub(/~ /, ''), # Remove ~ if it exists
       @total_cutting_length = group_def.total_cutting_length == 0 ? nil : DimensionUtils.instance.format_to_readable_length(group_def.total_cutting_length)
       @total_cutting_area = group_def.total_cutting_area == 0 ? nil : DimensionUtils.instance.format_to_readable_area(group_def.total_cutting_area)
-      @total_cutting_volume = group_def.total_cutting_volume == 0 ? nil : DimensionUtils.instance.format_to_readable_volume(group_def.total_cutting_volume)
+      @total_cutting_volume = group_def.total_cutting_volume == 0 ? nil : DimensionUtils.instance.format_to_readable_volume(group_def.total_cutting_volume, group_def.material_type)
       @total_final_area = group_def.total_final_area == 0 ? nil : DimensionUtils.instance.format_to_readable_area(group_def.total_final_area)
       @invalid_final_area_part_count = group_def.invalid_final_area_part_count
       @show_cutting_dimensions = group_def.show_cutting_dimensions

--- a/src/ladb_opencutlist/ruby/model/cutlist/groupdef.rb
+++ b/src/ladb_opencutlist/ruby/model/cutlist/groupdef.rb
@@ -12,7 +12,7 @@ module Ladb::OpenCutList
       @material_id = ''
       @material_name = ''
       @material_display_name = ''
-      @material_type = MaterialAttributes::TYPE_UNKNOW
+      @material_type = MaterialAttributes::TYPE_UNKNOWN
       @material_color = nil
       @material_grained = false
       @std_available = true
@@ -38,7 +38,7 @@ module Ladb::OpenCutList
     # -----
 
     def self.generate_group_id(material, material_attributes, std_info)
-      Digest::MD5.hexdigest("#{material.nil? ? 0 : material_attributes.uuid}#{material_attributes.type > MaterialAttributes::TYPE_UNKNOW ? '|' + DimensionUtils.to_max_precision_f(std_info[:width].to_l).to_s + 'x' + DimensionUtils.to_max_precision_f(std_info[:thickness].to_l).to_s : ''}")
+      Digest::MD5.hexdigest("#{material.nil? ? 0 : material_attributes.uuid}#{material_attributes.type > MaterialAttributes::TYPE_UNKNOWN ? '|' + DimensionUtils.to_max_precision_f(std_info[:width].to_l).to_s + 'x' + DimensionUtils.to_max_precision_f(std_info[:thickness].to_l).to_s : ''}")
     end
 
     # -----

--- a/src/ladb_opencutlist/ruby/tool/highlight_part_tool.rb
+++ b/src/ladb_opencutlist/ruby/tool/highlight_part_tool.rb
@@ -108,7 +108,7 @@ module Ladb::OpenCutList
             draw_def[:face_triangles].concat(_compute_children_faces_tirangles(view, instance_info.entity.definition.entities, instance_info.transformation))
 
             # Compute back and front face arrows
-            if group.material_type != MaterialAttributes::TYPE_UNKNOW
+            if group.material_type != MaterialAttributes::TYPE_UNKNOWN
 
               order = [ 1, 2, 3 ]
               if part.auto_oriented

--- a/src/ladb_opencutlist/ruby/utils/dimension_utils.rb
+++ b/src/ladb_opencutlist/ruby/utils/dimension_utils.rb
@@ -27,6 +27,7 @@
 
   UNIT_SIGN_METER_3 = 'm³'
   UNIT_SIGN_FEET_3 = 'ft³'
+  UNIT_SIGN_BOARD_FEET_3 = 'FBM'
 
   class DimensionUtils
 
@@ -148,7 +149,7 @@
         i
       end
     end
-    
+
     # Take a single dimension as a string and
     # 1. add units if none are present, assuming that no units means model units
     # 2. prepend zero if just unit given (may happen!)
@@ -160,7 +161,7 @@
       i = i.strip
       nu = ""
       sum = 0
-      if i.is_a?(String) 
+      if i.is_a?(String)
         if match = i.match(/^(~?\s*)(\d*(([.,])\d*)?)?\s*(#{UNIT_SIGN_MILLIMETER}|#{UNIT_SIGN_CENTIMETER}|#{UNIT_SIGN_METER}|#{UNIT_SIGN_FEET}|#{UNIT_SIGN_INCHES})?$/)
           one, two, three, four, five = match.captures
           if five.nil?
@@ -203,7 +204,7 @@
      i = i.strip
      sum = 0
       # make sure the entry is a string and starts with the proper magic
-      if i.is_a?(String) 
+      if i.is_a?(String)
         if match = i.match(/^(\d*([.,]\d*)?)?\s*(#{UNIT_SIGN_MILLIMETER}|#{UNIT_SIGN_CENTIMETER}|#{UNIT_SIGN_METER}|#{UNIT_SIGN_FEET}|#{UNIT_SIGN_INCHES})?$/)
           one, two, three = match.captures
           #puts "i = #{'%7s' % i} => decimal/integer number::  #{'%7s' % one}   #{'%7s' % three}"
@@ -414,7 +415,7 @@
         unit_sign = UNIT_SIGN_METER_2
       else
         multiplier = 1 / 144.0
-        precision = [2, @length_precision].max
+        precision = [2, @length_precision-3].max
         unit_sign = UNIT_SIGN_FEET_2
       end
       format_value(f2, multiplier, precision, unit_sign)
@@ -422,9 +423,9 @@
 
     # Take a float containing a volume in inch³
     # and convert it to a string representation according to the
-    # local unit settings.
+    # local unit settings and the material_type (for Board Foot).
     #
-    def format_to_readable_volume(f3)
+    def format_to_readable_volume(f3, material_type)
       if f3.nil?
         return nil
       end
@@ -433,9 +434,15 @@
         precision = [3, @length_precision].max
         unit_sign = UNIT_SIGN_METER_3
       else
-        multiplier = 1 / 1728.0
-        precision = [2, @length_precision].max
-        unit_sign = UNIT_SIGN_FEET_3
+        if material_type == MaterialAttributes::TYPE_SOLID_WOOD
+          multiplier = 1 / 144.0
+          precision = [2, @length_precision-3].max
+          unit_sign = UNIT_SIGN_BOARD_FEET_3
+        else
+          multiplier = 1 / 1728.0
+          precision = [2, @length_precision-3].max
+          unit_sign = UNIT_SIGN_FEET_3
+        end
       end
       format_value(f3, multiplier, precision, unit_sign)
     end

--- a/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_export_worker.rb
+++ b/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_export_worker.rb
@@ -166,8 +166,8 @@ module Ladb::OpenCutList
                     next if @hidden_group_ids.include? group.id
                     group.parts.each { |part|
 
-                      no_cutting_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOW
-                      no_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOW && @hide_untyped_material_dimensions
+                      no_cutting_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOWN
+                      no_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOWN && @hide_untyped_material_dimensions
 
                       row = []
                       row.push(part.number)
@@ -244,8 +244,8 @@ module Ladb::OpenCutList
                     next if group.material_type == MaterialAttributes::TYPE_EDGE    # Edges don't have instances
                     group.parts.each { |part|
 
-                      no_cutting_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOW
-                      no_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOW && @hide_untyped_material_dimensions
+                      no_cutting_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOWN
+                      no_dimensions = group.material_type == MaterialAttributes::TYPE_UNKNOWN && @hide_untyped_material_dimensions
 
                       parts = part.is_a?(FolderPart) ? part.children : [ part ]
                       parts.each { |part|

--- a/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_generate_worker.rb
+++ b/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_generate_worker.rb
@@ -241,7 +241,7 @@ module Ladb::OpenCutList
           group_def.std_dimension_rounded = std_info[:dimension_rounded]
           group_def.std_width = std_info[:width]
           group_def.std_thickness = std_info[:thickness]
-          group_def.show_cutting_dimensions = material_attributes.type > MaterialAttributes::TYPE_UNKNOW && (material_attributes.l_length_increase > 0 || material_attributes.l_width_increase > 0)
+          group_def.show_cutting_dimensions = material_attributes.type > MaterialAttributes::TYPE_UNKNOWN && (material_attributes.l_length_increase > 0 || material_attributes.l_width_increase > 0)
 
           _store_group_def(group_def)
 
@@ -438,7 +438,7 @@ module Ladb::OpenCutList
         part_def.add_entity_name(entity.name)
         part_def.store_instance_info(instance_info)
 
-        if group_def.material_type != MaterialAttributes::TYPE_UNKNOW
+        if group_def.material_type != MaterialAttributes::TYPE_UNKNOWN
           if group_def.material_type == MaterialAttributes::TYPE_DIMENSIONAL
             group_def.total_cutting_length += part_def.cutting_size.length
           end
@@ -532,7 +532,7 @@ module Ladb::OpenCutList
                 (folder_part_def.tags == part_def.tags || @hide_tags) &&
                 (((folder_part_def.final_area.nil? ? 0 : folder_part_def.final_area) - (part_def.final_area.nil? ? 0 : part_def.final_area)).abs < 0.001 or @hide_final_areas) &&      # final_area workaround for rounding error
                 folder_part_def.edge_material_names == part_def.edge_material_names &&
-                ((folder_part_def.definition_id == part_def.definition_id && group_def.material_type == MaterialAttributes::TYPE_UNKNOW) || group_def.material_type > MaterialAttributes::TYPE_UNKNOW) && # Part with untyped materiel are folded only if they have the same definition
+                ((folder_part_def.definition_id == part_def.definition_id && group_def.material_type == MaterialAttributes::TYPE_UNKNOWN) || group_def.material_type > MaterialAttributes::TYPE_UNKNOWN) && # Part with untyped materiel are folded only if they have the same definition
                 folder_part_def.cumulable == part_def.cumulable
               if folder_part_def.children.empty?
                 first_child_part_def = part_defs.pop


### PR DESCRIPTION
When material is of TYPE_SOLID_WOOD, use [FBM](https://en.wikipedia.org/wiki/Board_foot) to display volume in summary. For other materials keep ft³.

Caveat:

If OpenCutList's material TYPE_SOLID_WOOD is used for anything else but rough lumber, the summary display will be "wrong" (12 times larger than ft³).

Solution:

Add an a global option to display FBM instead of ft³.