### PR TITLE
Added the ability to ignore the grain direction by part

### DIFF
--- a/src/ladb_opencutlist/js/plugins/jquery.ladb.tab-cutlist.js
+++ b/src/ladb_opencutlist/js/plugins/jquery.ladb.tab-cutlist.js
@@ -1368,6 +1368,7 @@
                 var $inputTags = $('#ladb_cutlist_part_input_tags', $modal);
                 var $inputOrientationLockedOnAxis = $('#ladb_cutlist_part_input_orientation_locked_on_axis', $modal);
                 var $inputSymmetrical = $('#ladb_cutlist_part_input_symmetrical', $modal);
+                var $inputIgnoreGrainDirection = $('#ladb_cutlist_part_input_ignore_grain_direction', $modal);
                 var $inputPartAxes = $('#ladb_cutlist_part_input_axes', $modal);
                 var $sortableAxes = $('#ladb_sortable_axes', $modal);
                 var $sortablePartAxes = $('#ladb_sortable_part_axes', $modal);
@@ -1670,6 +1671,7 @@
 
                             editedParts[i].orientation_locked_on_axis = $inputOrientationLockedOnAxis.is(':checked');
                             editedParts[i].symmetrical = $inputSymmetrical.is(':checked');
+                            editedParts[i].ignore_grain_direction = $inputIgnoreGrainDirection.is(":checked");
                             editedParts[i].axes_order = $inputPartAxes.val().length > 0 ? $inputPartAxes.val().split(',') : [];
                             editedParts[i].axes_origin_position = $selectPartAxesOriginPosition.val();
 

--- a/src/ladb_opencutlist/ruby/model/attributes/definition_attributes.rb
+++ b/src/ladb_opencutlist/ruby/model/attributes/definition_attributes.rb
@@ -9,7 +9,7 @@ module Ladb::OpenCutList
     CUMULABLE_LENGTH = 1
     CUMULABLE_WIDTH = 2
 
-    attr_accessor :uuid, :cumulable, :instance_count_by_part, :mass, :price, :symmetrical, :tags, :orientation_locked_on_axis, :length_increase, :width_increase, :thickness_increase
+    attr_accessor :uuid, :cumulable, :instance_count_by_part, :mass, :price, :symmetrical, :ignore_grain_direction, :tags, :orientation_locked_on_axis, :length_increase, :width_increase, :thickness_increase
     attr_reader :definition
 
     @@cached_uuids = {}
@@ -155,6 +155,7 @@ module Ladb::OpenCutList
         @mass = @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'mass', '')
         @price = DefinitionAttributes.valid_price(@definition.get_attribute(Plugin::SU_ATTRIBUTE_DICTIONARY, 'Price', ''))
         @symmetrical = @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'symmetrical', false)
+        @ignore_grain_direction = @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'ignore_grain_direction', false);
         @tags = DefinitionAttributes.valid_tags(@definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'tags', @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'labels', []))) # BC for "labels" key
         @orientation_locked_on_axis = @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'orientation_locked_on_axis', false)
         @length_increase = @definition.get_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'length_increase', '0')
@@ -177,6 +178,7 @@ module Ladb::OpenCutList
         @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'mass', @mass)
         @definition.set_attribute(Plugin::SU_ATTRIBUTE_DICTIONARY, 'Price', @price)
         @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'symmetrical', @symmetrical)
+        @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'ignore_grain_direction', @ignore_grain_direction)
         @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'tags', @tags)
         @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'orientation_locked_on_axis', @orientation_locked_on_axis)
         @definition.set_attribute(Plugin::ATTRIBUTE_DICTIONARY, 'length_increase', DimensionUtils.instance.str_add_units(@length_increase))

--- a/src/ladb_opencutlist/ruby/model/cutlist/part.rb
+++ b/src/ladb_opencutlist/ruby/model/cutlist/part.rb
@@ -90,7 +90,7 @@ module Ladb::OpenCutList
 
   class Part < AbstractPart
 
-    attr_reader :definition_id, :is_dynamic_attributes_name, :resized, :flipped, :material_origins, :orientation_locked_on_axis, :symmetrical, :length_increase, :width_increase, :thickness_increase, :entity_ids, :entity_serialized_paths, :entity_names, :contains_blank_entity_names, :length_increased, :width_increased, :thickness_increased, :auto_oriented, :not_aligned_on_axes, :unused_instance_count, :layers, :multiple_layers, :edge_entity_ids, :normals_to_values, :normals_to_dimensions, :dimensions_to_normals
+    attr_reader :definition_id, :is_dynamic_attributes_name, :resized, :flipped, :material_origins, :orientation_locked_on_axis, :symmetrical, :ignore_grain_direction, :length_increase, :width_increase, :thickness_increase, :entity_ids, :entity_serialized_paths, :entity_names, :contains_blank_entity_names, :length_increased, :width_increased, :thickness_increased, :auto_oriented, :not_aligned_on_axes, :unused_instance_count, :layers, :multiple_layers, :edge_entity_ids, :normals_to_values, :normals_to_dimensions, :dimensions_to_normals
 
     def initialize(part_def, group, part_number)
       super(part_def, group)
@@ -103,6 +103,7 @@ module Ladb::OpenCutList
       @material_origins = part_def.material_origins
       @orientation_locked_on_axis = part_def.orientation_locked_on_axis
       @symmetrical = part_def.symmetrical
+      @ignore_grain_direction = part_def.ignore_grain_direction
       @length_increase = part_def.length_increase
       @width_increase = part_def.width_increase
       @thickness_increase = part_def.thickness_increase

--- a/src/ladb_opencutlist/ruby/model/cutlist/partdef.rb
+++ b/src/ladb_opencutlist/ruby/model/cutlist/partdef.rb
@@ -12,7 +12,7 @@ module Ladb::OpenCutList
     EDGES_Y = [ PartDef::EDGE_YMIN, PartDef::EDGE_YMAX ]
     EDGES_X = [ PartDef::EDGE_XMIN, PartDef::EDGE_XMAX ]
 
-    attr_accessor :id, :definition_id, :number, :saved_number, :name, :is_dynamic_attributes_name, :count, :cutting_size, :size, :scale, :flipped, :material_name, :material_origins, :cumulable, :instance_count_by_part, :mass, :price, :orientation_locked_on_axis, :tags, :symmetrical, :length_increase, :width_increase, :thickness_increase, :edge_count, :edge_pattern, :edge_entity_ids, :edge_length_decrement, :edge_width_decrement, :edge_decremented, :length_increased, :width_increased, :thickness_increased, :auto_oriented, :not_aligned_on_axes, :unused_instance_count, :layers, :final_area, :children_warning_count, :children_length_increased_count, :children_width_increased_count, :children_thickness_increased_count
+    attr_accessor :id, :definition_id, :number, :saved_number, :name, :is_dynamic_attributes_name, :count, :cutting_size, :size, :scale, :flipped, :material_name, :material_origins, :cumulable, :instance_count_by_part, :mass, :price, :orientation_locked_on_axis, :tags, :symmetrical, :ignore_grain_direction, :length_increase, :width_increase, :thickness_increase, :edge_count, :edge_pattern, :edge_entity_ids, :edge_length_decrement, :edge_width_decrement, :edge_decremented, :length_increased, :width_increased, :thickness_increased, :auto_oriented, :not_aligned_on_axes, :unused_instance_count, :layers, :final_area, :children_warning_count, :children_length_increased_count, :children_width_increased_count, :children_thickness_increased_count
     attr_reader :id, :edge_material_names, :edge_std_dimensions, :edge_errors, :entity_ids, :entity_serialized_paths, :entity_names, :contains_blank_entity_names, :children, :instance_infos, :edge_materials, :edge_group_defs
 
     def initialize(id)
@@ -36,6 +36,7 @@ module Ladb::OpenCutList
       @tags = ''
       @orientation_locked_on_axis = false
       @symmetrical = false
+      @ignore_grain_direction = false
       @length_increase = 0
       @width_increase = 0
       @thickness_increase = 0

--- a/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_cuttingdiagram_2d_worker.rb
+++ b/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_cuttingdiagram_2d_worker.rb
@@ -76,7 +76,14 @@ module Ladb::OpenCutList
       # they inherit the attribute from options
       parts.each { |part|
         for i in 1..part.count
-          e.add_box(part.cutting_length.to_l.to_f, part.cutting_width.to_l.to_f, options.rotatable, part)   # "to_l.to_f" Reconvert string representation of length to float to take advantage Sketchup precision
+
+          # allow overriding grain direction by part
+          can_rotate_part = options.rotatable
+          if part.ignore_grain_direction
+            can_rotate_part = true
+          end
+
+          e.add_box(part.cutting_length.to_l.to_f, part.cutting_width.to_l.to_f, can_rotate_part, part)   # "to_l.to_f" Reconvert string representation of length to float to take advantage Sketchup precision
         end
       }
 

--- a/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_generate_worker.rb
+++ b/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_generate_worker.rb
@@ -299,6 +299,7 @@ module Ladb::OpenCutList
           part_def.tags = definition_attributes.tags
           part_def.orientation_locked_on_axis = definition_attributes.orientation_locked_on_axis
           part_def.symmetrical = definition_attributes.symmetrical
+          part_def.ignore_grain_direction = definition_attributes.ignore_grain_direction
           part_def.length_increase = definition_attributes.length_increase
           part_def.width_increase = definition_attributes.width_increase
           part_def.thickness_increase = definition_attributes.thickness_increase

--- a/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_part_update_worker.rb
+++ b/src/ladb_opencutlist/ruby/worker/cutlist/cutlist_part_update_worker.rb
@@ -21,6 +21,7 @@ module Ladb::OpenCutList
         :tags,
         :orientation_locked_on_axis,
         :symmetrical,
+        :ignore_grain_direction,
         :axes_order,
         :axes_origin_position,
         :length_increase,
@@ -35,7 +36,9 @@ module Ladb::OpenCutList
       @parts_data = []
 
       parts_data = settings['parts_data']
+
       parts_data.each { |part_data|
+
         @parts_data << PartData.new(
             part_data['definition_id'],
             part_data['name'],
@@ -48,6 +51,7 @@ module Ladb::OpenCutList
             DefinitionAttributes.valid_tags(part_data['tags']),
             part_data['orientation_locked_on_axis'],
             part_data['symmetrical'],
+            part_data['ignore_grain_direction'],
             part_data['axes_order'],
             part_data['axes_origin_position'],
             part_data['length_increase'],
@@ -95,6 +99,7 @@ module Ladb::OpenCutList
               part_data.price != definition_attributes.price ||
               part_data.orientation_locked_on_axis != definition_attributes.orientation_locked_on_axis ||
               part_data.symmetrical != definition_attributes.symmetrical ||
+              part_data.ignore_grain_direction != definition_attributes.ignore_grain_direction ||
               part_data.tags != definition_attributes.tags ||
               part_data.length_increase != definition_attributes.length_increase ||
               part_data.width_increase != definition_attributes.width_increase ||
@@ -106,6 +111,7 @@ module Ladb::OpenCutList
             definition_attributes.tags = part_data.tags
             definition_attributes.orientation_locked_on_axis = part_data.orientation_locked_on_axis
             definition_attributes.symmetrical = part_data.symmetrical
+            definition_attributes.ignore_grain_direction = part_data.ignore_grain_direction
             definition_attributes.length_increase = part_data.length_increase
             definition_attributes.width_increase = part_data.width_increase
             definition_attributes.thickness_increase = part_data.thickness_increase

--- a/src/ladb_opencutlist/twig/tabs/cutlist/_list-row-col-name.twig
+++ b/src/ladb_opencutlist/twig/tabs/cutlist/_list-row-col-name.twig
@@ -13,8 +13,11 @@
             {% if part.is_dynamic_attributes_name %}<a href="#" class="ladb-tool-info" data-tab="infos" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.is_dynamic_attributes_name'|i18next }}"><i class="ladb-opencutlist-icon-dynamic-component"></i></a>{% endif %}
             {% if part.flipped %}<a href="#" class="ladb-tool-info" data-tab="axes" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.flipped'|i18next }}"><i class="ladb-opencutlist-icon-flipped"></i></a>{% endif %}
             {% if part.symmetrical %}<a href="#" class="ladb-tool-info" data-tab="axes" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.symmetrical'|i18next }}"><i class="ladb-opencutlist-icon-symmetrical"></i></a>{% endif %}
+
+            {% if part.ignore_grain_direction %}<a href="#" class="ladb-tool-info" data-tab="axes" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.ignore_grain_direction'|i18next }}"><i class="ladb-opencutlist-icon-grained-0"></i></a>{% endif %}
+
             {% if showCuttingDimensions or showBoxDimensions %}
-                {% if part.edge_count > 0 %}<a href="#" class="ladb-tool-info" data-tab="edges" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.has_edges'|i18next({ 'count':part.edge_count }) }}"><i class="ladb-opencutlist-icon-edge-{{ part.edge_pattern }}"></i></a>{% endif %}
+                {% if part.edge_count > 0 %}<a href="#" class="ladb-tool-info" data-tab="edges" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.has_edges'|i18next({ 'count':part.edge_count }) }}"><i class="ladb-opencutlist-icon-edge-{{ part.edge_pattern }}"></i></a>{% endif %}               
                 {% if part.auto_oriented %}<a href="#" class="ladb-tool-info" data-tab="axes" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.auto_oriented'|i18next }}"><i class="ladb-opencutlist-icon-auto-oriented"></i></a>{% endif %}
                 {% if part.resized %}<a href="#" class="ladb-tool-info" data-tab="infos" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.resized'|i18next }}"><i class="ladb-opencutlist-icon-resized"></i></a>{% endif %}
                 {% if part.orientation_locked_on_axis %}<a href="#" class="ladb-tool-info" data-tab="axes" data-toggle="tooltip" title="{{ 'tab.cutlist.tooltip.orientation_locked_on_axis'|i18next }}"><i class="ladb-opencutlist-icon-orientation-locked-on-axis"></i></a>{% endif %}

--- a/src/ladb_opencutlist/twig/tabs/cutlist/_modal-part.twig
+++ b/src/ladb_opencutlist/twig/tabs/cutlist/_modal-part.twig
@@ -160,6 +160,13 @@
                                 <input type="checkbox" id="ladb_cutlist_part_input_symmetrical"{% if part.symmetrical %} checked{% endif %}> <i class="ladb-opencutlist-icon-symmetrical"></i> {{ 'tab.cutlist.edit_part.symmetrical'|i18next }}
                             </label>
                         </div>
+                        <div class="checkbox">
+                            <div class="ladb-minitools ladb-minitools-right"><a tabindex="0" role="button" data-toggle="popover" data-trigger="hover" data-placement="left" title="{{ 'default.help'|i18next }}" data-content="{{ 'tab.cutlist.edit_part.ignore_grain_direction_help'|i18next }}"><i class="ladb-opencutlist-icon-help"></i></a></div>
+                            <label>
+                                <input type="checkbox" id="ladb_cutlist_part_input_ignore_grain_direction"{% if part.ignore_grain_direction %} checked{% endif %}> <i class="ladb-opencutlist-icon-grained-0"></i> {{ 'tab.cutlist.edit_part.ignore_grain_direction'|i18next }}
+                            </label>
+                        </div>
+
                     </div>
                     <div class="col-xs-offset-1 col-xs-10 alert alert-info ladb-alert-tips" style="margin-top: 20px;">
                         <div class="media">
@@ -402,6 +409,15 @@
                             </div>
                         </div>
                     {% endif %}
+                    {% if part.ignore_grain_direction %}
+                        <div class="media">
+                            <div class="media-left"><i class="ladb-opencutlist-icon-grained-0 ladb-opencutlist-icon-lg ladb-color-info"></i></div>
+                            <div class="media-body">
+                                {{ 'tab.cutlist.tooltip.ignore_grain_direction'|i18next }}
+                            </div>
+                        </div>
+                    {% endif %}
+
                 </div>
             </div>
         {% endif %}

--- a/src/ladb_opencutlist/yaml/i18n/en.yml
+++ b/src/ladb_opencutlist/yaml/i18n/en.yml
@@ -197,6 +197,7 @@ tab:
       resized: This part was resized with respect to its component definition
       flipped: This part is mirrored compared to its component definition
       symmetrical: Mirrored part detection is disabled on this part
+      ignore_grain_direction: Grain direction is ignored on this part
       auto_oriented: This part has been reoriented automatically
       add_label_filter: "Filtering on '{{ label }}'"
       remove_label_filter: "Remove filtering on '{{ label }}'"
@@ -286,6 +287,9 @@ tab:
       symmetrical: Disable mirrored part detection on this part
       symmetrical_help: |
         If this box is checked, the detection of a *mirrored part* will have no effect on the part.
+      ignore_grain_direction: Ignore grain direction on this part
+      ignore_grain_direction_help: |
+        If this box is checked, the grain direction of the material will be ignored for this part.
       size_increase: Oversizes
       size_increase_help: |
         Oversizes increase the dimensions of a single part.


### PR DESCRIPTION
I had a bit of time so decided to take a stab at solving for #288 myself.  This adds an option on the Axes tab of the Part Properties dialog to ignore the grain direction by part, and adjusts the cutting diagram accordingly.  From my local testing, it seems to work fine. 

The only thing that I'm aware of that this is missing is translations beyond English.